### PR TITLE
feat: add /context slash command for session token usage

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -24,8 +24,9 @@ import * as clearSessionsCmd from "./commands/clear-sessions.js";
 import * as lastCmd from "./commands/last.js";
 import * as queueCmd from "./commands/queue.js";
 import * as usageCmd from "./commands/usage.js";
+import * as contextCmd from "./commands/context.js";
 
-const commands = [registerCmd, unregisterCmd, statusCmd, stopCmd, autoApproveCmd, sessionsCmd, clearSessionsCmd, lastCmd, queueCmd, usageCmd];
+const commands = [registerCmd, unregisterCmd, statusCmd, stopCmd, autoApproveCmd, sessionsCmd, clearSessionsCmd, lastCmd, queueCmd, usageCmd, contextCmd];
 const commandMap = new Collection<
   string,
   { execute: (interaction: ChatInputCommandInteraction) => Promise<void> }

--- a/src/bot/commands/context.ts
+++ b/src/bot/commands/context.ts
@@ -1,0 +1,138 @@
+import {
+  ChatInputCommandInteraction,
+  SlashCommandBuilder,
+  EmbedBuilder,
+} from "discord.js";
+import { getProject } from "../../db/database.js";
+import { sessionManager } from "../../claude/session-manager.js";
+import { L } from "../../utils/i18n.js";
+
+export const data = new SlashCommandBuilder()
+  .setName("context")
+  .setDescription("Show current session's context window and token usage");
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
+  return tokens.toString();
+}
+
+function progressBar(pct: number, width = 20): string {
+  const filled = Math.round((pct / 100) * width);
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const channelId = interaction.channelId;
+  const project = getProject(channelId);
+
+  if (!project) {
+    await interaction.editReply({
+      content: L(
+        "This channel is not registered to any project.",
+        "이 채널은 어떤 프로젝트에도 등록되어 있지 않습니다.",
+      ),
+    });
+    return;
+  }
+
+  if (!sessionManager.isActive(channelId)) {
+    await interaction.editReply({
+      content: L(
+        "No active session in this channel. Send a message to start one.",
+        "이 채널에 활성 세션이 없습니다. 메시지를 보내 세션을 시작하세요.",
+      ),
+    });
+    return;
+  }
+
+  try {
+    const usage = await sessionManager.getContextUsage(channelId);
+    if (!usage) {
+      await interaction.editReply({
+        content: L(
+          "Could not retrieve context usage. The session may still be initializing.",
+          "컨텍스트 사용량을 가져올 수 없습니다. 세션이 아직 초기화 중일 수 있습니다.",
+        ),
+      });
+      return;
+    }
+
+    const pct = Math.round(usage.percentage);
+
+    // Main context bar
+    const lines: string[] = [
+      `\`${progressBar(pct)}\`  **${pct}%**  (${formatTokens(usage.totalTokens)} / ${formatTokens(usage.maxTokens)})`,
+    ];
+
+    // Category breakdown
+    if (usage.categories.length > 0) {
+      lines.push("");
+      lines.push(`**${L("Breakdown", "항목별")}**`);
+      for (const cat of usage.categories) {
+        if (cat.tokens === 0) continue;
+        const catPct = usage.totalTokens > 0
+          ? ((cat.tokens / usage.totalTokens) * 100).toFixed(1)
+          : "0";
+        lines.push(`> ${cat.name}: **${formatTokens(cat.tokens)}** (${catPct}%)`);
+      }
+    }
+
+    // API usage (cumulative input/output tokens)
+    if (usage.apiUsage) {
+      lines.push("");
+      lines.push(`**${L("API Token Usage", "API 토큰 사용량")}**`);
+      lines.push(`> ${L("Input", "입력")}: **${formatTokens(usage.apiUsage.input_tokens)}**`);
+      lines.push(`> ${L("Output", "출력")}: **${formatTokens(usage.apiUsage.output_tokens)}**`);
+      if (usage.apiUsage.cache_read_input_tokens > 0) {
+        lines.push(`> ${L("Cache read", "캐시 읽기")}: **${formatTokens(usage.apiUsage.cache_read_input_tokens)}**`);
+      }
+      if (usage.apiUsage.cache_creation_input_tokens > 0) {
+        lines.push(`> ${L("Cache write", "캐시 쓰기")}: **${formatTokens(usage.apiUsage.cache_creation_input_tokens)}**`);
+      }
+    }
+
+    // Message breakdown
+    if (usage.messageBreakdown) {
+      const mb = usage.messageBreakdown;
+      lines.push("");
+      lines.push(`**${L("Message Breakdown", "메시지 상세")}**`);
+      if (mb.userMessageTokens > 0)
+        lines.push(`> ${L("User messages", "사용자 메시지")}: **${formatTokens(mb.userMessageTokens)}**`);
+      if (mb.assistantMessageTokens > 0)
+        lines.push(`> ${L("Assistant messages", "어시스턴트 메시지")}: **${formatTokens(mb.assistantMessageTokens)}**`);
+      if (mb.toolCallTokens > 0)
+        lines.push(`> ${L("Tool calls", "도구 호출")}: **${formatTokens(mb.toolCallTokens)}**`);
+      if (mb.toolResultTokens > 0)
+        lines.push(`> ${L("Tool results", "도구 결과")}: **${formatTokens(mb.toolResultTokens)}**`);
+    }
+
+    // Auto-compact info
+    if (usage.isAutoCompactEnabled && usage.autoCompactThreshold) {
+      lines.push("");
+      lines.push(`💡 ${L(
+        `Auto-compact at ${usage.autoCompactThreshold}%`,
+        `${usage.autoCompactThreshold}%에서 자동 압축`,
+      )}`);
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle(L("📊 Context Window Usage", "📊 컨텍스트 윈도우 사용량"))
+      .setDescription(lines.join("\n"))
+      .setColor(0x7c3aed)
+      .setFooter({ text: `${L("Model", "모델")}: ${usage.model}` })
+      .setTimestamp();
+
+    await interaction.editReply({ embeds: [embed] });
+  } catch (error) {
+    console.error("[context] Failed to get context usage:", error);
+    await interaction.editReply({
+      content: L(
+        "Failed to retrieve context usage information.",
+        "컨텍스트 사용량 정보를 가져오는 데 실패했습니다.",
+      ),
+    });
+  }
+}

--- a/src/claude/session-manager.ts
+++ b/src/claude/session-manager.ts
@@ -1,4 +1,4 @@
-import { query, type Query } from "@anthropic-ai/claude-agent-sdk";
+import { query, type Query, type SDKControlGetContextUsageResponse } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { TextChannel } from "discord.js";
@@ -477,6 +477,16 @@ class SessionManager {
 
   isActive(channelId: string): boolean {
     return this.sessions.has(channelId);
+  }
+
+  async getContextUsage(channelId: string): Promise<SDKControlGetContextUsageResponse | null> {
+    const session = this.sessions.get(channelId);
+    if (!session) return null;
+    try {
+      return await session.queryInstance.getContextUsage();
+    } catch {
+      return null;
+    }
   }
 
   resolveApproval(


### PR DESCRIPTION
## Summary
- Adds `/context` slash command that shows the current session's context window and token usage
- Uses the Agent SDK's `getContextUsage()` API to display real-time token breakdown (categories, API input/output tokens, message details, auto-compact threshold)
- Shows a visual progress bar with percentage and formatted token counts

## Test plan
- [ ] Run `/context` with no active session → should show "no active session" message
- [ ] Run `/context` in an unregistered channel → should show "not registered" message
- [ ] Run `/context` during an active session → should display context usage embed with breakdown
- [ ] Verify token counts and categories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)