### PR TITLE
Fix stale resume (#10) + add CLAUDE_MODEL env var (#11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ BASE_PROJECT_DIR=/Users/you/projects
 RATE_LIMIT_PER_MINUTE=10
 # Show estimated API cost in task results (set false for Max plan users)
 SHOW_COST=true
+# Optional: pin a specific Claude model (leave blank to use CLI default)
+# Examples: claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5-20251001
+CLAUDE_MODEL=

--- a/src/claude/session-manager.ts
+++ b/src/claude/session-manager.ts
@@ -106,275 +106,302 @@ class SessionManager {
       }
     }, 15_000);
 
-    try {
-      const queryInstance = query({
-        prompt,
-        options: {
-          cwd: project.project_path,
-          permissionMode: "default",
-          env: { ...process.env, ANTHROPIC_API_KEY: undefined, PATH: `${path.dirname(process.execPath)}:${process.env.PATH ?? ""}` },
-          ...(resumeSessionId ? { resume: resumeSessionId } : {}),
+    const runQuery = (useResume: boolean) => query({
+      prompt,
+      options: {
+        cwd: project.project_path,
+        permissionMode: "default",
+        env: { ...process.env, ANTHROPIC_API_KEY: undefined, PATH: `${path.dirname(process.execPath)}:${process.env.PATH ?? ""}` },
+        ...(useResume && resumeSessionId ? { resume: resumeSessionId } : {}),
 
-          canUseTool: async (
-            toolName: string,
-            input: Record<string, unknown>,
-          ) => {
-            toolUseCount++;
+        canUseTool: async (
+          toolName: string,
+          input: Record<string, unknown>,
+        ) => {
+          toolUseCount++;
 
-            // Tool activity labels for Discord display
-            const toolLabels: Record<string, string> = {
-              Read: L("Reading files", "파일 읽는 중"),
-              Glob: L("Searching files", "파일 검색 중"),
-              Grep: L("Searching code", "코드 검색 중"),
-              Write: L("Writing file", "파일 작성 중"),
-              Edit: L("Editing file", "파일 편집 중"),
-              Bash: L("Running command", "명령어 실행 중"),
-              WebSearch: L("Searching web", "웹 검색 중"),
-              WebFetch: L("Fetching URL", "URL 가져오는 중"),
-              TodoWrite: L("Updating tasks", "작업 업데이트 중"),
-            };
-            const filePath = typeof input.file_path === "string"
-              ? ` \`${(input.file_path as string).split(/[\\/]/).pop()}\``
-              : "";
-            lastActivity = `${toolLabels[toolName] ?? `Using ${toolName}`}${filePath}`;
+          // Tool activity labels for Discord display
+          const toolLabels: Record<string, string> = {
+            Read: L("Reading files", "파일 읽는 중"),
+            Glob: L("Searching files", "파일 검색 중"),
+            Grep: L("Searching code", "코드 검색 중"),
+            Write: L("Writing file", "파일 작성 중"),
+            Edit: L("Editing file", "파일 편집 중"),
+            Bash: L("Running command", "명령어 실행 중"),
+            WebSearch: L("Searching web", "웹 검색 중"),
+            WebFetch: L("Fetching URL", "URL 가져오는 중"),
+            TodoWrite: L("Updating tasks", "작업 업데이트 중"),
+          };
+          const filePath = typeof input.file_path === "string"
+            ? ` \`${(input.file_path as string).split(/[\\/]/).pop()}\``
+            : "";
+          lastActivity = `${toolLabels[toolName] ?? `Using ${toolName}`}${filePath}`;
 
-            // Update status message if no text output yet
-            if (!hasTextOutput) {
-              const elapsed = Math.round((Date.now() - startTime) / 1000);
-              const timeStr = elapsed > 60
-                ? `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`
-                : `${elapsed}s`;
-              try {
-                await currentMessage.edit({
-                  content: `⏳ ${lastActivity} (${timeStr}) [${toolUseCount} tools used]`,
-                  components: [stopRow],
-                });
-              } catch (e) {
-                console.warn(`[tool-status] Failed to edit message for ${channelId}:`, e instanceof Error ? e.message : e);
-              }
+          // Update status message if no text output yet
+          if (!hasTextOutput) {
+            const elapsed = Math.round((Date.now() - startTime) / 1000);
+            const timeStr = elapsed > 60
+              ? `${Math.floor(elapsed / 60)}m ${elapsed % 60}s`
+              : `${elapsed}s`;
+            try {
+              await currentMessage.edit({
+                content: `⏳ ${lastActivity} (${timeStr}) [${toolUseCount} tools used]`,
+                components: [stopRow],
+              });
+            } catch (e) {
+              console.warn(`[tool-status] Failed to edit message for ${channelId}:`, e instanceof Error ? e.message : e);
+            }
+          }
+
+          // Handle AskUserQuestion with interactive Discord UI
+          if (toolName === "AskUserQuestion") {
+            const questions = (input.questions as AskQuestionData[]) ?? [];
+            if (questions.length === 0) {
+              return { behavior: "allow" as const, updatedInput: input };
             }
 
-            // Handle AskUserQuestion with interactive Discord UI
-            if (toolName === "AskUserQuestion") {
-              const questions = (input.questions as AskQuestionData[]) ?? [];
-              if (questions.length === 0) {
-                return { behavior: "allow" as const, updatedInput: input };
-              }
+            const answers: Record<string, string> = {};
 
-              const answers: Record<string, string> = {};
+            for (let qi = 0; qi < questions.length; qi++) {
+              const q = questions[qi];
+              const qRequestId = randomUUID();
+              const { embed, components } = createAskUserQuestionEmbed(
+                q,
+                qRequestId,
+                qi,
+                questions.length,
+              );
 
-              for (let qi = 0; qi < questions.length; qi++) {
-                const q = questions[qi];
-                const qRequestId = randomUUID();
-                const { embed, components } = createAskUserQuestionEmbed(
-                  q,
-                  qRequestId,
-                  qi,
-                  questions.length,
-                );
+              updateSessionStatus(channelId, "waiting");
+              await channel.send({ embeds: [embed], components });
 
-                updateSessionStatus(channelId, "waiting");
-                await channel.send({ embeds: [embed], components });
+              const answer = await new Promise<string | null>((resolve) => {
+                const timeout = setTimeout(() => {
+                  pendingQuestions.delete(qRequestId);
+                  // Clean up custom input if pending
+                  const ci = pendingCustomInputs.get(channelId);
+                  if (ci?.requestId === qRequestId) {
+                    pendingCustomInputs.delete(channelId);
+                  }
+                  resolve(null);
+                }, 5 * 60 * 1000);
 
-                const answer = await new Promise<string | null>((resolve) => {
-                  const timeout = setTimeout(() => {
+                pendingQuestions.set(qRequestId, {
+                  resolve: (ans) => {
+                    clearTimeout(timeout);
                     pendingQuestions.delete(qRequestId);
-                    // Clean up custom input if pending
-                    const ci = pendingCustomInputs.get(channelId);
-                    if (ci?.requestId === qRequestId) {
-                      pendingCustomInputs.delete(channelId);
-                    }
-                    resolve(null);
-                  }, 5 * 60 * 1000);
-
-                  pendingQuestions.set(qRequestId, {
-                    resolve: (ans) => {
-                      clearTimeout(timeout);
-                      pendingQuestions.delete(qRequestId);
-                      resolve(ans);
-                    },
-                    channelId,
-                  });
+                    resolve(ans);
+                  },
+                  channelId,
                 });
+              });
 
-                if (answer === null) {
-                  updateSessionStatus(channelId, "online");
-                  return {
-                    behavior: "deny" as const,
-                    message: L("Question timed out", "질문 시간 초과"),
-                  };
-                }
-
-                answers[q.header] = answer;
+              if (answer === null) {
+                updateSessionStatus(channelId, "online");
+                return {
+                  behavior: "deny" as const,
+                  message: L("Question timed out", "질문 시간 초과"),
+                };
               }
 
+              answers[q.header] = answer;
+            }
+
+            updateSessionStatus(channelId, "online");
+            return {
+              behavior: "allow" as const,
+              updatedInput: { ...input, answers },
+            };
+          }
+
+          // Auto-approve read-only tools
+          const readOnlyTools = ["Read", "Glob", "Grep", "WebSearch", "WebFetch", "TodoWrite"];
+          if (readOnlyTools.includes(toolName)) {
+            return { behavior: "allow" as const, updatedInput: input };
+          }
+
+          // Check auto-approve setting
+          const currentProject = getProject(channelId);
+          if (currentProject?.auto_approve) {
+            return { behavior: "allow" as const, updatedInput: input };
+          }
+
+          // Ask user via Discord buttons
+          const requestId = randomUUID();
+          const { embed, row } = createToolApprovalEmbed(
+            toolName,
+            input,
+            requestId,
+          );
+
+          updateSessionStatus(channelId, "waiting");
+          await channel.send({
+            embeds: [embed],
+            components: [row],
+          });
+
+          // Wait for user decision (timeout 5 min)
+          return new Promise((resolve) => {
+            const timeout = setTimeout(() => {
+              pendingApprovals.delete(requestId);
               updateSessionStatus(channelId, "online");
-              return {
-                behavior: "allow" as const,
-                updatedInput: { ...input, answers },
-              };
-            }
+              resolve({ behavior: "deny" as const, message: "Approval timed out" });
+            }, 5 * 60 * 1000);
 
-            // Auto-approve read-only tools
-            const readOnlyTools = ["Read", "Glob", "Grep", "WebSearch", "WebFetch", "TodoWrite"];
-            if (readOnlyTools.includes(toolName)) {
-              return { behavior: "allow" as const, updatedInput: input };
-            }
-
-            // Check auto-approve setting
-            const currentProject = getProject(channelId);
-            if (currentProject?.auto_approve) {
-              return { behavior: "allow" as const, updatedInput: input };
-            }
-
-            // Ask user via Discord buttons
-            const requestId = randomUUID();
-            const { embed, row } = createToolApprovalEmbed(
-              toolName,
-              input,
-              requestId,
-            );
-
-            updateSessionStatus(channelId, "waiting");
-            await channel.send({
-              embeds: [embed],
-              components: [row],
-            });
-
-            // Wait for user decision (timeout 5 min)
-            return new Promise((resolve) => {
-              const timeout = setTimeout(() => {
+            pendingApprovals.set(requestId, {
+              resolve: (decision) => {
+                clearTimeout(timeout);
                 pendingApprovals.delete(requestId);
                 updateSessionStatus(channelId, "online");
-                resolve({ behavior: "deny" as const, message: "Approval timed out" });
-              }, 5 * 60 * 1000);
-
-              pendingApprovals.set(requestId, {
-                resolve: (decision) => {
-                  clearTimeout(timeout);
-                  pendingApprovals.delete(requestId);
-                  updateSessionStatus(channelId, "online");
-                  resolve(
-                    decision.behavior === "allow"
-                      ? { behavior: "allow" as const, updatedInput: input }
-                      : { behavior: "deny" as const, message: decision.message ?? "Denied by user" },
-                  );
-                },
-                channelId,
-              });
+                resolve(
+                  decision.behavior === "allow"
+                    ? { behavior: "allow" as const, updatedInput: input }
+                    : { behavior: "deny" as const, message: decision.message ?? "Denied by user" },
+                );
+              },
+              channelId,
             });
-          },
+          });
         },
-      });
+      },
+    });
 
-      // Store the active session
-      this.sessions.set(channelId, {
-        queryInstance,
-        channelId,
-        sessionId: resumeSessionId ?? null,
-        dbId,
-      });
+    let queryInstance = runQuery(Boolean(resumeSessionId));
+    let attemptedResume = Boolean(resumeSessionId);
 
-      for await (const message of queryInstance) {
-        // Capture session ID
-        if (
-          message.type === "system" &&
-          "subtype" in message &&
-          message.subtype === "init"
-        ) {
-          const sdkSessionId = (message as { session_id?: string }).session_id;
-          if (sdkSessionId) {
-            const active = this.sessions.get(channelId);
-            if (active) active.sessionId = sdkSessionId;
-            upsertSession(dbId, channelId, sdkSessionId, "online");
-          }
-        }
+    try {
+      retry: while (true) {
+        // Store the active session (update each iteration so Stop button uses current instance)
+        this.sessions.set(channelId, {
+          queryInstance,
+          channelId,
+          sessionId: resumeSessionId ?? null,
+          dbId,
+        });
 
-        // Handle streaming text
-        if (message.type === "assistant" && "content" in message) {
-          const content = message.content;
-          if (Array.isArray(content)) {
-            for (const block of content) {
-              if ("text" in block && typeof block.text === "string") {
-                responseBuffer += block.text;
-                hasTextOutput = true;
+        try {
+          for await (const message of queryInstance) {
+            // Capture session ID
+            if (
+              message.type === "system" &&
+              "subtype" in message &&
+              message.subtype === "init"
+            ) {
+              const sdkSessionId = (message as { session_id?: string }).session_id;
+              if (sdkSessionId) {
+                const active = this.sessions.get(channelId);
+                if (active) active.sessionId = sdkSessionId;
+                upsertSession(dbId, channelId, sdkSessionId, "online");
               }
             }
-          }
 
-          // Throttled message edit
-          const now = Date.now();
-          if (now - lastEditTime >= EDIT_INTERVAL && responseBuffer.length > 0) {
-            lastEditTime = now;
-            const chunks = splitMessage(responseBuffer);
-            try {
-              await currentMessage.edit({ content: chunks[0] || "...", components: [] });
-              // Send additional chunks as new messages
-              for (let i = 1; i < chunks.length; i++) {
-                currentMessage = await channel.send(chunks[i]);
-                responseBuffer = chunks.slice(i + 1).join("");
+            // Handle streaming text
+            if (message.type === "assistant" && "content" in message) {
+              const content = message.content;
+              if (Array.isArray(content)) {
+                for (const block of content) {
+                  if ("text" in block && typeof block.text === "string") {
+                    responseBuffer += block.text;
+                    hasTextOutput = true;
+                  }
+                }
               }
-            } catch (e) {
-              console.warn(`[stream] Failed to edit message for ${channelId}, sending new:`, e instanceof Error ? e.message : e);
-              currentMessage = await channel.send(
-                chunks[chunks.length - 1] || "...",
+
+              // Throttled message edit
+              const now = Date.now();
+              if (now - lastEditTime >= EDIT_INTERVAL && responseBuffer.length > 0) {
+                lastEditTime = now;
+                const chunks = splitMessage(responseBuffer);
+                try {
+                  await currentMessage.edit({ content: chunks[0] || "...", components: [] });
+                  // Send additional chunks as new messages
+                  for (let i = 1; i < chunks.length; i++) {
+                    currentMessage = await channel.send(chunks[i]);
+                    responseBuffer = chunks.slice(i + 1).join("");
+                  }
+                } catch (e) {
+                  console.warn(`[stream] Failed to edit message for ${channelId}, sending new:`, e instanceof Error ? e.message : e);
+                  currentMessage = await channel.send(
+                    chunks[chunks.length - 1] || "...",
+                  );
+                }
+              }
+            }
+
+            // Handle result
+            if ("result" in message) {
+              const resultMsg = message as {
+                result?: string;
+                total_cost_usd?: number;
+                duration_ms?: number;
+              };
+
+              // Flush remaining buffer
+              if (responseBuffer.length > 0) {
+                const chunks = splitMessage(responseBuffer);
+                try {
+                  await currentMessage.edit(chunks[0] || L("Done.", "완료."));
+                  for (let i = 1; i < chunks.length; i++) {
+                    await channel.send(chunks[i]);
+                  }
+                } catch (e) {
+                  console.warn(`[flush] Failed to edit final message for ${channelId}:`, e instanceof Error ? e.message : e);
+                }
+              }
+
+              // Replace stop button with completed button
+              try {
+                await currentMessage.edit({
+                  components: [createCompletedButton()],
+                });
+              } catch (e) {
+                console.warn(`[complete] Failed to update completed button for ${channelId}:`, e instanceof Error ? e.message : e);
+              }
+
+              // Send result embed
+              const resultText = resultMsg.result ?? L("Task completed", "작업 완료");
+              const resultEmbed = createResultEmbed(
+                resultText,
+                resultMsg.total_cost_usd ?? 0,
+                resultMsg.duration_ms ?? 0,
+                getConfig().SHOW_COST,
               );
-            }
-          }
-        }
+              await channel.send({ embeds: [resultEmbed] });
 
-        // Handle result
-        if ("result" in message) {
-          const resultMsg = message as {
-            result?: string;
-            total_cost_usd?: number;
-            duration_ms?: number;
-          };
-
-          // Flush remaining buffer
-          if (responseBuffer.length > 0) {
-            const chunks = splitMessage(responseBuffer);
-            try {
-              await currentMessage.edit(chunks[0] || L("Done.", "완료."));
-              for (let i = 1; i < chunks.length; i++) {
-                await channel.send(chunks[i]);
+              // Detect auth/credit errors in result and suggest re-login
+              const resultAuthKeywords = ["credit balance", "not authenticated", "unauthorized", "authentication", "login required", "auth token", "expired", "not logged in", "please run /login"];
+              const lowerResult = resultText.toLowerCase();
+              if (resultAuthKeywords.some((kw) => lowerResult.includes(kw))) {
+                await channel.send(L(
+                  "🔑 Claude Code is not logged in. Please open a terminal on the host PC and run `claude login` to authenticate, then try again.",
+                  "🔑 Claude Code 로그인이 필요합니다. 호스트 PC에서 터미널을 열고 `claude login`을 실행하여 인증 후 다시 시도해 주세요.",
+                ));
               }
-            } catch (e) {
-              console.warn(`[flush] Failed to edit final message for ${channelId}:`, e instanceof Error ? e.message : e);
+
+              updateSessionStatus(channelId, "idle");
+              hasResult = true;
             }
           }
+          break;
+        } catch (innerError) {
+          // If the resume attempt crashed before any user-visible output, the saved
+          // session_id is likely stale. Silently retry once without resume.
+          const rawMsg = innerError instanceof Error ? innerError.message : String(innerError);
+          const resumeStale =
+            attemptedResume &&
+            !hasTextOutput &&
+            !hasResult &&
+            (rawMsg.includes("process exited with code") ||
+              rawMsg.includes("No conversation found") ||
+              rawMsg.includes("session not found") ||
+              /resume/i.test(rawMsg));
+          if (!resumeStale) throw innerError;
 
-          // Replace stop button with completed button
-          try {
-            await currentMessage.edit({
-              components: [createCompletedButton()],
-            });
-          } catch (e) {
-            console.warn(`[complete] Failed to update completed button for ${channelId}:`, e instanceof Error ? e.message : e);
-          }
-
-          // Send result embed
-          const resultText = resultMsg.result ?? L("Task completed", "작업 완료");
-          const resultEmbed = createResultEmbed(
-            resultText,
-            resultMsg.total_cost_usd ?? 0,
-            resultMsg.duration_ms ?? 0,
-            getConfig().SHOW_COST,
-          );
-          await channel.send({ embeds: [resultEmbed] });
-
-          // Detect auth/credit errors in result and suggest re-login
-          const resultAuthKeywords = ["credit balance", "not authenticated", "unauthorized", "authentication", "login required", "auth token", "expired", "not logged in", "please run /login"];
-          const lowerResult = resultText.toLowerCase();
-          if (resultAuthKeywords.some((kw) => lowerResult.includes(kw))) {
-            await channel.send(L(
-              "🔑 Claude Code is not logged in. Please open a terminal on the host PC and run `claude login` to authenticate, then try again.",
-              "🔑 Claude Code 로그인이 필요합니다. 호스트 PC에서 터미널을 열고 `claude login`을 실행하여 인증 후 다시 시도해 주세요.",
-            ));
-          }
-
-          updateSessionStatus(channelId, "idle");
-          hasResult = true;
+          console.warn(`[session] Resume failed for ${channelId}, retrying without resume:`, rawMsg);
+          upsertSession(dbId, channelId, null, "online");
+          queryInstance = runQuery(false);
+          attemptedResume = false;
+          continue retry;
         }
       }
     } catch (error) {

--- a/src/claude/session-manager.ts
+++ b/src/claude/session-manager.ts
@@ -113,6 +113,7 @@ class SessionManager {
         permissionMode: "default",
         env: { ...process.env, ANTHROPIC_API_KEY: undefined, PATH: `${path.dirname(process.execPath)}:${process.env.PATH ?? ""}` },
         ...(useResume && resumeSessionId ? { resume: resumeSessionId } : {}),
+        ...(getConfig().CLAUDE_MODEL ? { model: getConfig().CLAUDE_MODEL } : {}),
 
         canUseTool: async (
           toolName: string,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,6 +13,10 @@ const envSchema = z.object({
     .enum(["true", "false"])
     .default("true")
     .transform((v) => v === "true"),
+  CLAUDE_MODEL: z
+    .string()
+    .optional()
+    .transform((v) => (v && v.length > 0 ? v : undefined)),
 });
 
 export type Config = z.infer<typeof envSchema>;


### PR DESCRIPTION
Closes #10, Closes #11.

## Summary
- **#10 Bug fix**: Silently retry once without `resume` when the saved `session_id` is stale, eliminating the `⏳ → ❌ → ⏳ → ✅` double-card UX that users saw after bot restart.
- **#11 Feature**: Optional `CLAUDE_MODEL` env var to pin a specific Claude model variant. Unset = SDK default (no breaking change).

## Changes

### `src/claude/session-manager.ts`
- Extract `query()` creation into `runQuery(useResume: boolean)` closure.
- Wrap the for-await message loop in `retry: while (true)` with an inner try/catch.
- On inner error, if `attemptedResume && !hasTextOutput && !hasResult` and the error message matches resume-stale patterns (`"process exited with code"`, `"No conversation found"`, `"session not found"`, `/resume/i`), clear the DB `session_id`, re-run `query()` without resume, and `continue retry`. Only retries once (`attemptedResume = false`).
- Genuine mid-stream failures (after any output/result) still surface to the user as before.
- Inject `model: CLAUDE_MODEL` into `query()` options when set.

### `src/utils/config.ts`
- Add `CLAUDE_MODEL: z.string().optional().transform(...)` — empty string normalized to `undefined`.

### `.env.example`
- Add `CLAUDE_MODEL=` entry with examples in comment.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 93/93 passing
- [ ] Manual #10: register channel → send message → delete `~/.claude/projects/<slug>/*.jsonl` → restart bot → send message → should see `⏳ Thinking...` → `✅ Task Complete` with no ❌ card
- [ ] Manual #10 negative: valid resume path still works (no regression)
- [ ] Manual #10 boundary: mid-stream crashes still show ❌ card (retry gated by `!hasTextOutput && !hasResult`)
- [ ] Manual #11: set `CLAUDE_MODEL=claude-haiku-4-5-20251001` → verify model pinned
- [ ] Manual #11: leave unset → default behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)